### PR TITLE
add Support for ISI(ciw) format

### DIFF
--- a/lib/ref_parsers.rb
+++ b/lib/ref_parsers.rb
@@ -3,6 +3,7 @@ require "ref_parsers/line_parser"
 require "ref_parsers/ris_parser"
 require "ref_parsers/endnote_parser"
 require "ref_parsers/pubmed_parser"
+require "ref_parsers/ciw_parser"
 
 module RefParsers
 end

--- a/lib/ref_parsers/ciw_parser.rb
+++ b/lib/ref_parsers/ciw_parser.rb
@@ -1,0 +1,24 @@
+
+module RefParsers
+ 
+
+ class CIWParser < LineParser
+
+
+    def initialize
+     @footer_regex = "EF"
+	 @header_regexes =["FN","VR"]
+     @type_key = "PT"
+     @terminator_key = "ER"
+     @line_regex =  /^(AB|AF|AP|AR|AU|BE|BN|BP|C1|CA|CL|CR|CY|CT|DE|DI|DT|ED|EM|EP|ER|EF|EI|FN|FU|FX|GA|HO|ID|IS|J9|JI|LA|NR|OI|PD|PA|PG|PI|PN|PT|PU|PY|PM|RP|RI|SC|SE|SI|SN|SO|SP|SU|TC|TI|UT|U1|U2|VL|VR|WC|WP|Z9|ZB|Z8|ZS)(\s*(.*))?$/
+     @key_regex_order = 1
+     @value_regex_order = 2
+     @regex_match_length = 4
+ 
+  
+    end
+    
+
+ end
+
+end

--- a/lib/ref_parsers/ciw_parser.rb
+++ b/lib/ref_parsers/ciw_parser.rb
@@ -1,11 +1,7 @@
-
 module RefParsers
- 
-
  class CIWParser < LineParser
 
-
-    def initialize
+   def initialize
      @footer_regex = "EF"
 	 @header_regexes =["FN","VR"]
      @type_key = "PT"
@@ -14,11 +10,7 @@ module RefParsers
      @key_regex_order = 1
      @value_regex_order = 2
      @regex_match_length = 4
- 
-  
     end
-    
-
- end
-
+	
+  end
 end

--- a/lib/ref_parsers/ciw_parser.rb
+++ b/lib/ref_parsers/ciw_parser.rb
@@ -10,7 +10,7 @@ module RefParsers
 	 @header_regexes =["FN","VR"]
      @type_key = "PT"
      @terminator_key = "ER"
-     @line_regex =  /^(AB|AF|AP|AR|AU|BE|BN|BP|C1|CA|CL|CR|CY|CT|DE|DI|DT|ED|EM|EP|ER|EF|EI|FN|FU|FX|GA|HO|ID|IS|J9|JI|LA|NR|OI|PD|PA|PG|PI|PN|PT|PU|PY|PM|RP|RI|SC|SE|SI|SN|SO|SP|SU|TC|TI|UT|U1|U2|VL|VR|WC|WP|Z9|ZB|Z8|ZS)(\s*(.*))?$/
+     @line_regex =  /^(AB|AF|AP|AR|AU|BE|BN|BP|C1|CA|CL|CR|CY|CT|DE|DI|DT|ED|EM|EP|ER|EF|EI|FN|FU|FX|GA|HO|ID|IS|J9|JI|LA|NR|OI|PD|PA|PG|PI|PN|PT|PU|PY|PM|RP|RI|SC|SE|SI|SN|SO|SP|SU|TC|TI|UT|U1|U2|UR|VL|VR|WC|WP|Z9|ZB|Z8|ZS)(\s*(.*))?$/
      @key_regex_order = 1
      @value_regex_order = 2
      @regex_match_length = 4

--- a/lib/ref_parsers/ciw_parser.rb
+++ b/lib/ref_parsers/ciw_parser.rb
@@ -2,8 +2,8 @@ module RefParsers
  class CIWParser < LineParser
 
    def initialize
-     @footer_regex = "EF"
-	 @header_regexes =["FN","VR"]
+     @footer_regex = /^EF\s*$/
+     @header_regexes = [/^FN/, /^VR/]
      @type_key = "PT"
      @terminator_key = "ER"
      @line_regex =  /^(AB|AF|AP|AR|AU|BE|BN|BP|C1|CA|CL|CR|CY|CT|DE|DI|DT|ED|EM|EP|ER|EF|EI|FN|FU|FX|GA|HO|ID|IS|J9|JI|LA|NR|OI|PD|PA|PG|PI|PN|PT|PU|PY|PM|RP|RI|SC|SE|SI|SN|SO|SP|SU|TC|TI|UT|U1|U2|UR|VL|VR|WC|WP|Z9|ZB|Z8|ZS)(\s*(.*))?$/

--- a/lib/ref_parsers/line_parser.rb
+++ b/lib/ref_parsers/line_parser.rb
@@ -105,7 +105,7 @@ protected
 
     def hash_entry(fields)
       entry = {'type' => fields.first[:value]}
-      #fields.delete_at 0
+      fields.delete_at 0
       fields.each do |field|
         if entry[field[:key]].nil? # empty value
           entry[field[:key]] = field[:value]

--- a/lib/ref_parsers/line_parser.rb
+++ b/lib/ref_parsers/line_parser.rb
@@ -105,7 +105,7 @@ protected
 
     def hash_entry(fields)
       entry = {'type' => fields.first[:value]}
-      fields.delete_at 0
+      #fields.delete_at 0
       fields.each do |field|
         if entry[field[:key]].nil? # empty value
           entry[field[:key]] = field[:value]

--- a/spec/ciw_parser_spec.rb
+++ b/spec/ciw_parser_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+include RefParsers
+
+describe CIWParser do
+  let(:parser) { CIWParser.new }
+
+  describe '.initialize' do
+    it 'parses the input file correctly' do
+      parser.open 'spec/support/example.ciw'
+    end
+  end
+end

--- a/spec/support/example.ciw
+++ b/spec/support/example.ciw
@@ -1,0 +1,26 @@
+FN Thomson Reuters Web of Science™
+VR 1.0
+PT J
+AU Eltabakh, Mohamed
+   Aref, Walid
+   Elmagarmid, Ahmed
+   Ouzzani, Mourad
+TI HandsOn DB: Managing Data Dependencies Involving Human Actions(title)
+SO IEEE TRANSACTIONS ON KNOWLEDGE AND DATA ENGINEERING(journal title, in full)
+DT Article
+AB abstract
+VL 26
+IS 9
+BP 2193
+EP 2206
+J9 CLIN GENET
+JI Clin. Genet.
+PD SEP
+PY 2014
+LA ENGLISH
+UR www.rayyan.qcri.com
+SN 1041-4347
+UT WOS:000341571100009
+ER
+
+EF

--- a/test.rb
+++ b/test.rb
@@ -10,7 +10,8 @@ raise "USAGE: #{__FILE__} <input-file>" if filename.nil?
 parsers = {
   '.ris' => RefParsers::RISParser,
   '.enw' => RefParsers::EndNoteParser,
-  '.nbib' => RefParsers::PubMedParser
+  '.nbib' => RefParsers::PubMedParser,
+  '.ciw' => RefParsers::CIWParser
 }
 klass = parsers[File.extname(filename)]
 if klass


### PR DESCRIPTION


The ISI/Web of Science data exchange format is used by Thomson's Web of Science export function. We have not been able to find an official definition, but have used information from the Ruby Forge web site instead.