### PR TITLE
Parsing issues task final

### DIFF
--- a/lib/ref_parsers.rb
+++ b/lib/ref_parsers.rb
@@ -4,6 +4,7 @@ require "ref_parsers/ris_parser"
 require "ref_parsers/endnote_parser"
 require "ref_parsers/pubmed_parser"
 require "ref_parsers/ciw_parser"
+require "ref_parsers/line_parsing_exception.rb"
 
 module RefParsers
 end

--- a/lib/ref_parsers/ciw_parser.rb
+++ b/lib/ref_parsers/ciw_parser.rb
@@ -1,7 +1,7 @@
 module RefParsers
  class CIWParser < LineParser
 
-   def initialize
+   def initialize(missing_type_key_action=:raise_exception)
      @footer_regex = /^EF\s*$/
      @header_regexes = [/^FN/, /^VR/]
      @type_key = "PT"
@@ -10,8 +10,12 @@ module RefParsers
      @key_regex_order = 1
      @value_regex_order = 2
      @regex_match_length = 4
-     super
+     @missing_type_key_action = missing_type_key_action
+     super()
     end
-	
+
+    def friendly_name()
+      "Web of Science/CIW Parser"
+    end	
   end
 end

--- a/lib/ref_parsers/endnote_parser.rb
+++ b/lib/ref_parsers/endnote_parser.rb
@@ -1,7 +1,7 @@
 module RefParsers
   class EndNoteParser < LineParser
 
-    def initialize
+    def initialize()
       @type_key = "0"
       @types = ["Generic", "Artwork", "Audiovisual Material", "Bill", "Book", "Book Section", "Case", "Chart or Table", "Classical Work", "Computer Program", "Conference Paper", "Conference Proceedings", "Edited Book", "Equation", "Electronic Article", "Electronic Book", "Electronic Source", "Figure", "Film or Broadcast", "Government Document", "Hearing", "Journal Article", "Legal Rule/Regulation", "Magazine Article", "Manuscript", "Map", "Newspaper Article", "Online Database", "Online Multimedia", "Patent", "Personal Communication", "Report", "Statute", "Thesis", "Unpublished Work", "Unused 1", "Unused 2", "Unused 3"]
       @terminator_key = nil
@@ -9,8 +9,11 @@ module RefParsers
       @key_regex_order = 1
       @value_regex_order = 2
       @regex_match_length = 3
-      super
+      super()
     end
 
+    def friendly_name()
+      "EndNote/ENW Parser"
+    end	
   end
 end

--- a/lib/ref_parsers/line_parser.rb
+++ b/lib/ref_parsers/line_parser.rb
@@ -24,7 +24,7 @@ module RefParsers
     end
 
     def open(filename)
-      parse File.read(filename, encoding: 'UTF-8')
+      parse File.read(filename, mode: 'r:bom|UTF-8')
     end
 
     def parse(body)

--- a/lib/ref_parsers/line_parser.rb
+++ b/lib/ref_parsers/line_parser.rb
@@ -4,12 +4,13 @@ module RefParsers
   class LineParsingException < StandardError
     attr_reader :line_number
     attr_reader :line_string
+    attr_reader :inner_exception
 
     def initialize(message, line_number, line_string, innerException = nil)
       super("#{message} #{'(See inner exception for details)' if innerException} | Line# #{line_number} | Line Text: #{line_string}")
-      self.set_backtrace(innerException.backtrace) if innerException
       @line_number = line_number
       @line_string = line_string
+      @inner_exception = inner_exception
     end
   end
 

--- a/lib/ref_parsers/line_parser.rb
+++ b/lib/ref_parsers/line_parser.rb
@@ -1,47 +1,130 @@
 module RefParsers
   NEWLINE_MERGER = '     '
 
-  class LineParsingException < StandardError
-    attr_reader :line_number
-    attr_reader :line_string
-    attr_reader :inner_exception
+  class ParsingLogSummary
+    attr_reader :number_of_entries
+    attr_reader :number_of_keys
+    attr_reader :number_of_terminators
+    attr_reader :number_of_ignored_entries
+    attr_reader :number_of_imported_entries_without_type
+    
+    def initialize(parser_friendly_name)
+      @number_of_entries = 0
+      @number_of_keys = 0
+      @number_of_terminators = 0
+      @number_of_ignored_entries = 0
+      @number_of_imported_entries_without_type = 0
+      @parser_friendly_name = parser_friendly_name
+    end
 
-    def initialize(message, line_number, line_string, innerException = nil)
-      super("#{message} #{'(See inner exception for details)' if innerException} | Line# #{line_number} | Line Text: #{line_string}")
-      @line_number = line_number
-      @line_string = line_string
-      @inner_exception = inner_exception
+    def report_entries(entries)
+      @number_of_entries = entries.length
+    end
+
+    def detail_found(detail)
+      @number_of_keys += 1 if detail.is_type_found
+      @number_of_terminators += 1 if detail.is_terminator_found
+      @number_of_ignored_entries += 1 if detail.action == :ignore_entry
+      @number_of_imported_entries_without_type += 1 if detail.action == :import_entry
+    end
+
+    def to_s
+      "Parser: #{@parser_friendly_name} Number of returned entries: #{@number_of_entries} | Number of keys: #{@number_of_keys} | Number of terminators: #{@number_of_terminators} | Ignored entries: #{@number_of_ignored_entries} | Entries without type key but still imported: #{@number_of_imported_entries_without_type}"
     end
   end
 
   class LineParser
+    module MissingTypeKeyWithTerminatorAction
+      :raise_exception #fail the entire file. This is the default behavior for backward compatibility
+      :ignore_entry #ignore that entry but import other entries with a type_key in the file
+      :import_entry #will import the entry anyway. and will report it in the ParsingLogSummary.
+    end
+
     def initialize
       hash = {"@type_key" => @type_key, "@key_regex_order" => @key_regex_order, "@line_regex" => @line_regex,
               "@value_regex_order" => @value_regex_order, "@regex_match_length" => @regex_match_length}
 
       missing = hash.select{|k, v| v.nil?}
+      @missing_type_key_action = :raise_exception if !@missing_type_key_action
       raise "#{missing.keys.join(", ")} are missing" unless missing.empty?    
     end
 
-    def open(filename)
-      parse File.read(filename, mode: 'r:bom|UTF-8')
+    def open(filename, &summary_handler)
+      parse(File.read(filename, mode: 'r:bom|UTF-8'), &summary_handler)
     end
 
-    def parse(body)
+    def parse(body, &summary_handler)
       lines = body.split(/\n\r|\r\n|\n|\r/)
       entries = []
+      first_tag_override = nil
+      if summary_handler
+        summary = ParsingLogSummary.new(self.friendly_name)
+      end
       next_line = skip_header(lines)
       begin
         entry_found = false
-        next_line = parse_entry(lines, next_line) do |entry|
-          entries << entry
+        entry_is_null = false
+        detail = parse_entry(lines, next_line, first_tag_override) do |entry|
+          if entry
+            entries << entry
+          end
           entry_found = true
         end
+        if summary_handler
+          summary.detail_found(detail)
+        end
+        first_tag_override = nil
+        next_line = detail.next_line if detail.next_line
+
+        if detail.is_empty 
+          break
+        elsif detail.is_terminator_found #terminator same line as the same line as the beginning of next segment. I would have prefered to have a pass for fixing text before going through lines. But, The current version just loads the entire file into memory, that can be a potential performance problem and will be replaced by streaming the file instead and then the text fixing pass won't work 
+          full_line_text = lines[detail.current_line]
+          if detail.parsed and detail.parsed[:value]
+            trimed = detail.parsed[:value].strip
+            has_first, first = try_get_first_line(trimed)
+            if has_first and first
+              first_tag_override = first
+            end
+          end
+        end
       end while entry_found
+      if summary_handler
+        summary.report_entries(entries)
+        summary_handler.call(summary)
+      end
       entries
     end
 
+    def friendly_name()
+      self.class.name
+    end
 protected
+    class ParsingInfoDetail
+      attr_accessor :first_line
+      attr_accessor :is_type_found
+      attr_accessor :is_empty
+      attr_accessor :is_terminator_found
+      attr_accessor :is_eof_found
+      attr_accessor :current_line
+      attr_accessor :parsed
+      attr_accessor :action
+
+      def next_line
+        return @current_line + 1 
+      end
+
+      def initialize()
+        @current_line = 0
+        @first_line = 0
+        @is_type_found = false
+        @is_empty = false
+        @is_terminator_found = false
+        @is_eof_found = false
+        @action = nil
+      end
+    end
+
     def skip_header(lines)
       return 0 unless @header_regexes
       next_line = 0
@@ -58,56 +141,134 @@ protected
       return {footer: true} if line.match(@footer_regex)
     end
 
-    def parse_entry(lines, next_line)
+    def parse_entry(lines, next_line, first_line_override = nil)
       begin
-        return next_line if next_line >= lines.length
-        line_text = lines[next_line]
-        begin
-          first = parse_first_line(line_text)
-        rescue => ex
-          raise LineParsingException.new("Error parsing first line", next_line, line_text, ex)
-        end
-        next_line = next_line + 1
-      end while first.nil?
-
-      return if first[:footer]
-
-      fields = [first]
-
-      last_parsed = {}
-      begin
-        parsed = parse_line(lines[next_line])
-        next_line = next_line + 1
-        if parsed
-          return if parsed[:footer]
-          stop = false
-          if parsed[:key] == "-1"
-            parsed[:key] = last_parsed[:key]
-            parsed[:value] = "#{last_parsed[:value]}#{NEWLINE_MERGER}#{parsed[:value]}"
-            fields.delete_at fields.length - 1
-          elsif @terminator_key && parsed[:key] == @terminator_key
-            yield hash_entry(fields)
-            return next_line
-          end
-          last_parsed = parsed
-          fields << parsed
-        elsif @terminator_key.nil? || next_line >= lines.length
-          stop = true
-          yield hash_entry(fields)
-          return next_line
+        detail = ParsingInfoDetail.new()
+        detail.current_line = next_line
+        action = nil
+        if !first_line_override
+          begin
+            if detail.current_line >= lines.length
+              detail.is_eof_found = true
+              return detail 
+            end
+            line_text = lines[detail.current_line]
+            begin
+              if !is_valid_line(line_text)
+                first = nil
+              else
+                first, action = parse_first_line(line_text)
+              end
+            rescue => ex
+              raise RefParsers::LineParsingException.new("Error parsing first line", detail.current_line, line_text, ex)
+            end
+            detail.current_line = detail.current_line + 1
+          end while first.nil?
         else
-          stop = false
+          first = first_line_override
         end
-      end until stop
+
+        detail.action = action
+
+        if action.nil?
+          detail.is_type_found = true
+          detail.first_line = detail.current_line
+        end
+
+        if first[:footer]
+          detail.is_empty = true 
+          return detail
+        end
+
+        fields = [first]
+
+        last_parsed = {}
+        begin
+          parsed = parse_line(lines[detail.current_line])
+          if parsed
+            detail.parsed = parsed
+            if parsed[:footer]
+              if fields and fields.length > 1
+                if action != :ignore_entry
+                  yield hash_entry(fields)
+                else
+                  yield nil
+                end
+              else
+                detail.is_empty = true
+              end
+              return detail
+            end
+            stop = false
+            if parsed[:key] == "-1"
+              parsed[:key] = last_parsed[:key]
+              parsed[:value] = "#{last_parsed[:value]}#{NEWLINE_MERGER}#{parsed[:value]}"
+              fields.delete_at fields.length - 1
+            elsif @terminator_key && parsed[:key] == @terminator_key
+              detail.is_terminator_found = true
+              if action != :ignore_entry
+                yield hash_entry(fields)
+              else
+                yield nil
+              end
+              return detail
+            end
+            last_parsed = parsed
+            fields << parsed
+          elsif @terminator_key.nil? || detail.next_line >= lines.length
+            stop = true
+            detail.is_eof_found = true
+            if action != :ignore_entry
+              yield hash_entry(fields)
+            else
+              yield nil
+            end
+            return detail
+          else
+            stop = false
+          end
+          detail.current_line += 1
+        end until stop
+      end
+    end
+    
+    def try_get_first_line(line)
+      first = parse_line(line, /^\d+/) # skip leading entry numbers
+      return  (first and first[:key] == @type_key), first
     end
 
     def parse_first_line(line)
-      first = parse_line(line, /^\d+/)  # skip leading entry numbers
-      return first if first.nil? || first[:footer]
-      raise "First line should start with #{@type_key}" if first[:key] != @type_key
+      action = nil
+      has_first, first = try_get_first_line(line) 
+
+      return first, nil  if first.nil? || first[:footer] 
+      
+      if !has_first
+        fail_first_line = lambda {
+            raise "First line should start with #{@type_key}" 
+        }
+        if @terminator_key.nil?
+          fail_first_line.call()
+        elsif @missing_type_key_action == :ignore_entry
+          action = :ignore_entry
+        elsif @missing_type_key_action == :import_entry
+          action = :import_entry
+        else
+          fail_first_line.call()
+        end
+      end
       # lets not check for semantics here, leave it for the library client
       # raise "#{line}: Reference type should be one of #{@types.inspect}" unless @types.include? first[:value]
-      first
+      return first, action, has_first
+    end
+
+    def is_valid_line(line)
+      ignores = []
+      ignores << /^\s*$/
+      ignores << /^\d+/
+      return false if line.nil? || ignores.any?{|e| line.match(e)}
+       m = line.match(@line_regex)
+       return !m.nil?
     end
 
     def parse_line(line, *ignores)
@@ -126,8 +287,7 @@ protected
 
     def hash_entry(fields)
       entry = {'type' => fields.first[:value]}
-      fields.delete_at 0
-      fields.each do |field|
+      fields.drop(1).each do |field| #skip type field
         if entry[field[:key]].nil? # empty value
           entry[field[:key]] = field[:value]
         elsif entry[field[:key]].instance_of? Array # array of values

--- a/lib/ref_parsers/line_parsing_exception.rb
+++ b/lib/ref_parsers/line_parsing_exception.rb
@@ -1,0 +1,14 @@
+module RefParsers
+  class LineParsingException < StandardError
+    attr_reader :line_number
+    attr_reader :line_string
+    attr_reader :inner_exception
+
+    def initialize(message, line_number, line_string, innerException = nil)
+      super("#{message} #{'(See inner exception for details)' + innerException.message if innerException} | Line# #{line_number} | Line Text: #{line_string}")
+      @line_number = line_number
+      @line_string = line_string
+      @inner_exception = inner_exception
+    end
+  end
+end

--- a/lib/ref_parsers/pubmed_parser.rb
+++ b/lib/ref_parsers/pubmed_parser.rb
@@ -1,15 +1,18 @@
 module RefParsers
   class PubMedParser < LineParser
 
-    def initialize
+    def initialize()
       @type_key = "PMID"
       @terminator_key = nil
       @line_regex = /^(\w{1,4})\s{0,3}- (.*)$/
       @key_regex_order = 1
       @value_regex_order = 2
       @regex_match_length = 3
-      super
+      super()
     end
     
+    def friendly_name()
+      "PubMed/NBIB Parser"
+    end	 
   end
 end

--- a/lib/ref_parsers/ris_parser.rb
+++ b/lib/ref_parsers/ris_parser.rb
@@ -1,7 +1,7 @@
 module RefParsers
   class RISParser < LineParser
 
-    def initialize
+    def initialize(missing_type_key_action=:raise_exception)
       @type_key = "TY"
       @types = %w(ABST ADVS ART BILL BOOK CASE CHAP COMP CONF CTLG DATA ELEC GEN HEAR ICOMM INPR JFULL JOUR EJOUR MAP MGZN MPCT MUSIC NEWS PAMP PAT PCOMM RPRT SER SLIDE SOUND STAT THES UNBILl UNPB VIDEO)
       @terminator_key = "ER"
@@ -9,8 +9,12 @@ module RefParsers
       @key_regex_order = 1
       @value_regex_order = 3
       @regex_match_length = 4
-      super
+      @missing_type_key_action = missing_type_key_action
+      super()
     end
     
+    def friendly_name()
+      "Refman/RIS Parser"
+    end	
   end
 end

--- a/spec/ciw_parser_spec.rb
+++ b/spec/ciw_parser_spec.rb
@@ -3,11 +3,15 @@ require 'spec_helper'
 include RefParsers
 
 describe CIWParser do
-  let(:parser) { CIWParser.new }
+  let(:parser) { CIWParser.new(:import_entry) }
 
   describe '.initialize' do
     it 'parses the input file correctly' do
-      parser.open 'spec/support/example.ciw'
+      entries = parser.open 'spec/support/example.ciw'
+      expect(entries.length).to eq(3)
+    end
+    it 'should have the friendly_name' do
+      expect(parser.friendly_name()).to eq("Web of Science/CIW Parser")
     end
   end
 end

--- a/spec/endnote_parser_spec.rb
+++ b/spec/endnote_parser_spec.rb
@@ -9,5 +9,9 @@ describe EndNoteParser do
     it 'parses the input file correctly' do
       parser.open 'spec/support/example.enw'
     end
+
+    it 'should have the friendly_name' do
+      expect(parser.friendly_name()).to eq("EndNote/ENW Parser")
+    end
   end
 end

--- a/spec/line_parser_spec.rb
+++ b/spec/line_parser_spec.rb
@@ -37,12 +37,25 @@ require 'spec_helper'
     end
 
     describe '#open' do
-      let(:filename) { 'spec/support/example.txt' }
-      let(:body) { "example content\n" }
+      #A little bit testing the framework rather than this library code, but this is useful for documentation and making sure no regressions.
+      context "when opening a UTF-8 file that has a BOM bytes" do
+          let(:filename) { 'spec/support/example_utf8_with_bom.txt' }
+          let(:body) { "مثال لمحتوى - Example content\n" } #UTF-8 Text 
 
-      it 'calls parse with the contents of the input file' do
-        expect(parser).to receive(:parse).with(body)
-        parser.open(filename)
+          it 'calls parse with the contents of the input file' do
+            expect(parser).to receive(:parse).with(body)
+            parser.open(filename)
+          end
+      end
+
+      context "when opening a file with UTF-8 format" do
+          let(:filename) { 'spec/support/example_utf8_without_bom.txt' }
+          let(:body) { "مثال لمحتوى - Example content\n" } #UTF-8 Text 
+
+          it 'calls parse with the contents of the input file in utf-8' do
+            expect(parser).to receive(:parse).with(body)
+            parser.open(filename)
+          end
       end
     end
 
@@ -159,7 +172,7 @@ require 'spec_helper'
           expect(parser.send(:parse_entry, lines, next_line)).to eq(next_line)
         end
       end
-
+      
       context "if the length of the lines isn't greater than next line" do
         let(:lines){[double("lines"), double("lines2")]}
         let(:next_line){0}

--- a/spec/line_parser_spec.rb
+++ b/spec/line_parser_spec.rb
@@ -1,145 +1,260 @@
 require 'spec_helper'
 
-  class LineParserChild < RefParsers::LineParser
-    def initialize()
-        @type_key = "0"
-        @line_regex = /\d/
-        @key_regex_order = 1
-        @value_regex_order = 2
-        @regex_match_length = 3
-        super
+class LineParserChild < RefParsers::LineParser
+  def initialize(type_key = "0", line_regex = /\d/, terminator_key = nil, regex_match_length = 3, missing_type_key_action=:raise_exception, footer_regex = nil)
+    @type_key = type_key
+    @terminator_key = terminator_key
+    @line_regex = line_regex
+    @footer_regex = footer_regex
+    @key_regex_order = 1
+    @value_regex_order = 2
+    @regex_match_length = regex_match_length
+    @missing_type_key_action = missing_type_key_action
+    super()
+  end
+end
+
+class LineParserEmptyChild < RefParsers::LineParser
+  def initialize
+    super
+  end
+end
+
+include RefParsers
+
+describe LineParser do
+  let(:parser) { LineParserChild.new }
+
+  describe '.initialize' do
+    context "when the required values aren't specified" do
+      it "should raise an error stating which ones aren't there" do
+        expect{LineParserEmptyChild.new}.to raise_error(RuntimeError, "@type_key, @key_regex_order, @line_regex, @value_regex_order, @regex_match_length are missing")
+      end
+    end
+
+    context "when the values are all specified" do
+      it "should not raise an error" do
+        expect{LineParserChild.new}.not_to raise_error
+      end
+    end
+
+    context "when calling friendly_name" do
+      it "should return the name of the calss by default" do
+        expect(LineParserChild.new().friendly_name()).to eq("LineParserChild")
+      end
     end
   end
 
-  class LineParserEmptyChild < RefParsers::LineParser
-    def initialize
-      super
+  describe '#open' do
+    #A little bit testing the framework rather than this library code, but this is useful for documentation and making sure no regressions.
+    context "when opening a UTF-8 file that has a BOM bytes" do
+      let(:filename) { 'spec/support/example_utf8_with_bom.txt' }
+      let(:body) { "مثال لمحتوى - Example content\n" } #UTF-8 Text 
+
+      it 'calls parse with the contents of the input file' do
+        expect(parser).to receive(:parse).with(body)
+        parser.open(filename)
+      end
+    end
+
+    context "when opening a file with UTF-8 format" do
+      let(:filename) { 'spec/support/example_utf8_without_bom.txt' }
+      let(:body) { "مثال لمحتوى - Example content\n" } #UTF-8 Text 
+
+      it 'calls parse with the contents of the input file in utf-8' do
+        expect(parser).to receive(:parse).with(body)
+        parser.open(filename)
+      end
     end
   end
 
-  include RefParsers
+  describe '#parse' do
+    let(:body){double("body")}
+    let(:lines){double("line")}
+    let(:next_line){double("next_line")}
+    let(:log){double("log")}
+    let(:empty_ret) {double("empty_ret", :next_line => nil, :is_empty => true, :is_terminator_found => false)}
 
-  describe LineParser do
-    let(:parser) { LineParserChild.new }
+    before{
+      allow(body).to receive(:split) {lines}
+      allow(parser).to receive(:skip_header).with(lines) {next_line}
+    }
 
-    describe '.initialize' do
-      context "when the required values aren't specified" do
-        it "should raise an error stating which ones aren't there" do
-          expect{LineParserEmptyChild.new}.to raise_error(RuntimeError, "@type_key, @key_regex_order, @line_regex, @value_regex_order, @regex_match_length are missing")
-        end
-      end
-
-      context "when the values are all specified" do
-        it "should not raise an error" do
-          expect{LineParserChild.new}.not_to raise_error
-        end
-      end
-    end
-
-    describe '#open' do
-      #A little bit testing the framework rather than this library code, but this is useful for documentation and making sure no regressions.
-      context "when opening a UTF-8 file that has a BOM bytes" do
-          let(:filename) { 'spec/support/example_utf8_with_bom.txt' }
-          let(:body) { "مثال لمحتوى - Example content\n" } #UTF-8 Text 
-
-          it 'calls parse with the contents of the input file' do
-            expect(parser).to receive(:parse).with(body)
-            parser.open(filename)
-          end
-      end
-
-      context "when opening a file with UTF-8 format" do
-          let(:filename) { 'spec/support/example_utf8_without_bom.txt' }
-          let(:body) { "مثال لمحتوى - Example content\n" } #UTF-8 Text 
-
-          it 'calls parse with the contents of the input file in utf-8' do
-            expect(parser).to receive(:parse).with(body)
-            parser.open(filename)
-          end
-      end
-    end
-
-    describe '#parse' do
-      let(:body){double("body")}
-      let(:lines){double("line")}
-      let(:next_line){double("next_line")}
-      
-      before{
-        allow(body).to receive(:split) {lines}
-        allow(parser).to receive(:skip_header).with(lines) {next_line}
+    context "when parse entry doesn't yield" do
+      before {
+        allow(parser).to receive(:parse_entry).with(lines, next_line, nil).and_return(empty_ret) 
       }
 
-      context "when parse entry doesn't yield" do
-        before {
-          allow(parser).to receive(:parse_entry).with(lines, next_line) {double}
-        }
-        
-        it "should return an empty array" do
-          expect(parser.parse(body)).to eq([])
-        end
+      it "should return an empty array" do
+        expect(parser.parse(body)).to eq([])
+      end
+    end
+
+    context "when parse entry have a problem with first line" do
+      before {
+        allow(parser).to receive(:parse_first_line).with("line").and_raise("SOME_ERROR")
+        allow(parser).to receive(:is_valid_line) {true}
+      }
+
+      it "should throw an exception of type RefParsers::LineParsingException" do
+        expect{parser.send(:parse_entry, %w(line line2), 0, nil)}.to raise_error RefParsers::LineParsingException
+      end
+    end
+
+    context "when parse entry yields once" do
+      let(:new_next_line) {double("new_next_line", :next_line => 1, :is_empty => false, :is_terminator_found => false)}
+      let(:entry) {double("entry")}
+
+      before {
+        allow(parser).to receive(:parse_entry).with(lines, next_line, nil).and_yield(entry).and_return(new_next_line)
+        allow(parser).to receive(:parse_entry).with(lines, 1, nil).and_return(empty_ret) 
+      }
+
+      it "should return an array consisting of one entry" do
+        expect(parser.parse(body)).to eq([entry])
       end
 
-      context "when parse entry yields once" do
-        let(:new_next_line) {double("new_next_line")}
-        let(:entry) {double("entry")}
-        
+      context "when parse entry yields twice" do
+        let(:final_next_line) {double("final_next_line", :next_line => 2, :is_empty => false, :is_terminator_found => false)}
         before {
-          allow(parser).to receive(:parse_entry).with(lines, next_line).and_yield(entry).and_return(new_next_line)
-          allow(parser).to receive(:parse_entry).with(lines, new_next_line) {double}
+          allow(parser).to receive(:parse_entry).with(lines, 1, nil).and_yield(entry).and_return(final_next_line)
+          allow(parser).to receive(:parse_entry).with(lines, 2, nil).and_return(empty_ret) 
         }
 
         it "should return an array consisting of one entry" do
-          expect(parser.parse(body)).to eq([entry])
-        end
-
-        context "when parse entry yields twice" do
-          let(:final_next_line) {double("final_next_line")}
-          
-          before {
-            allow(parser).to receive(:parse_entry).with(lines, new_next_line).and_yield(entry).and_return(final_next_line)
-            allow(parser).to receive(:parse_entry).with(lines, final_next_line) {double}
-          }
-
-          it "should return an array consisting of one entry" do
-            expect(parser.parse(body)).to eq([entry, entry])
-          end
+          expect(parser.parse(body)).to eq([entry, entry])
         end
       end
     end
 
-    describe '#skip_header' do
-      it "returns 0 when no header regexes specified" do
-        expect(parser.send(:skip_header, %w(1 2 3))).to eq(0)
+    context "when passing summary block" do
+      let(:parser) { LineParserChild.new("TK", /(TK) =(.*)/) }
+      let(:lines){["TK =TEST"]}
+      let(:next_line){0}
+      before {
+        parser.parse(body) do |s|
+          @summary = s
+        end
+      }
+      it "should call the summary block with summary info" do
+        expect(@summary).to be_kind_of(RefParsers::ParsingLogSummary)
       end
 
-      context "when header regexes are specified" do
-        before {
-          parser.instance_variable_set('@header_regexes', [/h1/, /h2/])
-        }
+      it "should have not empty to_s" do
+        expect(@summary.to_s()).not_to be_empty()
+      end
 
-        it "raises an error if anything is preceding header lines" do
-          expect{parser.send(:skip_header, %w(x h1 h2))}.to raise_error RuntimeError, /Header line/
-        end
-
-        it "raises an error if header lines are not in order" do
-          expect{parser.send(:skip_header, %w(h2 h1))}.to raise_error RuntimeError, /Header line/
-        end
-
-        it "raises an error if header lines are not present" do
-          expect{parser.send(:skip_header, %w(x1 x2))}.to raise_error RuntimeError, /Header line/
-        end
-
-        it "raises an error if header lines are not successive" do
-          expect{parser.send(:skip_header, %w(h1 x h2))}.to raise_error RuntimeError, /Header line/
-        end
-
-        it "returns the next line after header lines when they are matching" do
-          expect(parser.send(:skip_header, %w(h1 h2 c1 c2))).to eq(2)
-        end
+      it "should have correct number of returned entries" do
+        expect(@summary.number_of_entries).to eq(1)
       end
     end
 
-    describe '#detect_footer' do
+    context "when type_key is at the same line of end token" do
+      let(:parser) { LineParserChild.new("TK", /(TK|EN) =(.*)/, "EN") }
+      let(:lines){["TK =TEST", "EN =      \t      TK =TEST2"]}
+      let(:next_line){0}
+       it "should have correct number of returned entries" do
+         expect(parser.parse(body).entries.length).to eq(2)
+      end
+    end
+
+    context "when type_key is not present but the terminator is there if :missing_type_key_action is set to :import_entry" do
+      let(:parser) { LineParserChild.new("TK", /(TK|EN|AF) =(.*)/, "EN", 3, :import_entry) }
+      let(:lines){["AF = TEST TEXT", "EN =", "TK =TEST2", "EN ="]}
+      let(:next_line){0}
+       it "should have correct number of returned entries" do
+         expect(parser.parse(body).entries.length).to eq(2)
+      end
+    end
+
+    context "when type_key is not present but the terminator is there if :missing_type_key_action is set to :import_entry and eof was found" do
+      let(:parser) { LineParserChild.new("TK", /(TK|EN|AF) =(.*)/, "EN", 3, :import_entry) }
+      let(:lines){["AF = TEST TEXT", "EN =", "TK =TEST2"]}
+      let(:next_line){0}
+       it "should have correct number of returned entries" do
+         expect(parser.parse(body).entries.length).to eq(2)
+      end
+    end
+
+    context "when type_key is not present but the terminator is there if :missing_type_key_action is set to :ignore_entry and eof was found" do
+      let(:parser) { LineParserChild.new("TK", /(TK|EN|AF) =(.*)/, "EN", 3, :ignore_entry) }
+      let(:lines){["TK =TEST", "AF = TEST TEXT", "EN =", "AF = TEST2"]}
+      let(:next_line){0}
+       it "should have correct number of returned entries" do
+         expect(parser.parse(body).entries.length).to eq(1)
+      end
+    end
+
+    context "when type_key is not present but the terminator is there if :missing_type_key_action is set to :ignore_entry" do
+      let(:parser) { LineParserChild.new("TK", /(TK|EN|AF) =(.*)/, "EN", 3, :ignore_entry) }
+      let(:lines){["AF =TEST TEXT", "EN =", "TK =TEST2", "EN ="]}
+      let(:next_line){0}
+       it "should have correct number of returned entries" do
+         expect(parser.parse(body).entries.length).to eq(1)
+      end
+    end
+
+    context "when type_key is not present but the terminator is there if :missing_type_key_action is set to :ignore_entry and footer was found" do
+      let(:parser) { LineParserChild.new("TK", /(TK|EN|AF|AF2) =(.*)/, "EN", 3, :ignore_entry, /^FT$/) }
+      let(:lines){["AF = TEST2", "AF2 = TEST2","FT"]}
+      let(:next_line){0}
+       it "should have correct number of returned entries" do
+         expect(parser.parse(body).entries.length).to eq(0)
+      end
+    end
+
+    context "when type_key is not present but the terminator is there if :missing_type_key_action is set to :raise_exception" do
+      let(:parser) { LineParserChild.new("TK", /(TK|EN|AF) =(.*)/, "EN", 3, :raise_exception) }
+      let(:lines){["AF =TEST TEXT", "EN =", "TK =TEST2", "EN ="]}
+      let(:next_line){0}
+      it "it should throw exception" do
+         expect{parser.parse(body)}.to raise_error RefParsers::LineParsingException
+      end
+    end
+
+    context "when there are info between last tag and " do
+      let(:parser) { LineParserChild.new("TK", /(TK|EN|AF) =(.*)/, "EN") }
+      let(:lines){["TK =TEST", "EN =", "  ", "Ss", "", "TK =TEST2"]}
+      let(:next_line){0}
+       it "should have correct number of returned entries" do
+         expect(parser.parse(body).entries.length).to eq(2)
+      end
+    end
+  end
+
+  describe '#skip_header' do
+    it "returns 0 when no header regexes specified" do
+      expect(parser.send(:skip_header, %w(1 2 3))).to eq(0)
+    end
+
+    context "when header regexes are specified" do
+      before {
+        parser.instance_variable_set('@header_regexes', [/h1/, /h2/])
+      }
+
+      it "raises an error if anything is preceding header lines" do
+        expect{parser.send(:skip_header, %w(x h1 h2))}.to raise_error RuntimeError, /Header line/
+      end
+
+      it "raises an error if header lines are not in order" do
+        expect{parser.send(:skip_header, %w(h2 h1))}.to raise_error RuntimeError, /Header line/
+      end
+
+      it "raises an error if header lines are not present" do
+        expect{parser.send(:skip_header, %w(x1 x2))}.to raise_error RuntimeError, /Header line/
+      end
+
+      it "raises an error if header lines are not successive" do
+        expect{parser.send(:skip_header, %w(h1 x h2))}.to raise_error RuntimeError, /Header line/
+      end
+
+      it "returns the next line after header lines when they are matching" do
+        expect(parser.send(:skip_header, %w(h1 h2 c1 c2))).to eq(2)
+      end
+    end
+  end
+
+  describe '#detect_footer' do
     it "returns nil when no footer regex specified" do
       expect(parser.send(:detect_footer, "l")).to eq(nil)
     end
@@ -157,390 +272,396 @@ require 'spec_helper'
         expect(parser.send(:detect_footer, "footer")).to eq({footer: true})
       end
     end
+  end
+
+  describe '#parse_entry' do
+    context "if the length of the lines are greater than next line" do
+      let(:lines){double("lines")}
+      let(:next_line){1}
+
+      before {
+        allow(lines).to receive(:length) {0}
+      }
+
+      it "should return next line" do
+        expect(parser.send(:parse_entry, lines, next_line).current_line).to eq(next_line)
+      end
     end
 
-    describe '#parse_entry' do
-      context "if the length of the lines are greater than next line" do
-        let(:lines){double("lines")}
-        let(:next_line){1}
-        
+    context "if the length of the lines isn't greater than next line" do
+      let(:lines){[double("lines"), double("lines2")]}
+      let(:next_line){0}
+
+      # testing the initial loop element
+      context "if parse_first_line(lines[next_line]) (next_line is 2) is not nil" do
+        let(:lines){[double("lines"), double("lines2")]}
+        let(:hash_entry){double("terminator_key")}
+
         before {
-          allow(lines).to receive(:length) {0}
+          allow(parser).to receive(:parse_first_line).with(lines[next_line]) {nil}
+          allow(parser).to receive(:parse_first_line).with(lines[next_line + 1]) {{}}
+          allow(parser).to receive(:parse_line).with(lines[next_line + 2]) {nil}
+          allow(parser).to receive(:hash_entry).with([{}]) {hash_entry}
+          allow(parser).to receive(:is_valid_line) {true}
         }
-        
-        it "should return next line" do
-          expect(parser.send(:parse_entry, lines, next_line)).to eq(next_line)
+
+        it "should return next_line + 2 and yield hash_entry(fields)" do
+          expect { |b|
+            detail = parser.send(:parse_entry, lines, next_line, &b)
+            expect(detail.next_line).to eq(next_line + 3)
+          }.to yield_with_args(hash_entry)
         end
       end
-      
-      context "if the length of the lines isn't greater than next line" do
-        let(:lines){[double("lines"), double("lines2")]}
-        let(:next_line){0}
 
-        # testing the initial loop element
-        context "if parse_first_line(lines[next_line]) (next_line is 2) is not nil" do
-          let(:lines){[double("lines"), double("lines2")]}
-          let(:hash_entry){double("terminator_key")}
+      context "if parse_first_line(lines[next_line]) (next line is 1) is not nil" do
+        before {
+          allow(parser).to receive(:hash_entry).with([first]) {hash_entry}
+          allow(parser).to receive(:parse_first_line).with(lines[next_line]) {first}
+          allow(parser).to receive(:is_valid_line) {true}
+        }
 
-          before {
-            allow(parser).to receive(:parse_first_line).with(lines[next_line]) {nil}
-            allow(parser).to receive(:parse_first_line).with(lines[next_line + 1]) {{}}
-            allow(parser).to receive(:parse_line).with(lines[next_line + 2]) {nil}
-            allow(parser).to receive(:hash_entry).with([{}]) {hash_entry}
-          }
+        context "if first[:footer] is not nil or false" do
+          let(:first){{footer: true}}
 
-          it "should return next_line + 2 and yield hash_entry(fields)" do
-            expect { |b|
-              ret = parser.send(:parse_entry, lines, next_line, &b)
-              expect(ret).to eq(next_line + 3)
-            }.to yield_with_args(hash_entry)
+          it "should return is_empty" do
+            expect(parser.send(:parse_entry, lines, next_line).is_empty{}).to eq(true)
           end
         end
 
-        context "if parse_first_line(lines[next_line]) (next line is 1) is not nil" do
-          before {
-            allow(parser).to receive(:hash_entry).with([first]) {hash_entry}
-            allow(parser).to receive(:parse_first_line).with(lines[next_line]) {first}
-          }
+        context "if first[:footer] is nil or false" do
+          let(:first){{}}
+          let(:terminator_key){double("fake_terminator_key")}
 
-          context "if first[:footer] is not nil or false" do
-            let(:first){{footer: true}}
-
-            it "should return nil" do
-              expect(parser.send(:parse_entry, lines, next_line)).to eq(nil)
+          shared_examples "yield and return next_line" do
+            it "should yield hash_entry(fields) and return next line" do
+              expect { |b|
+                detail = parser.send(:parse_entry, lines, next_line, &b)
+                expect(detail.next_line).to eq(next_line + 2)
+              }.to yield_with_args(hash_entry)
             end
           end
 
-          context "if first[:footer] is nil or false" do
-            let(:first){{}}
-            let(:terminator_key){double("fake_terminator_key")}
+          context "if parsed is not nil or false" do
+            before {
+              allow(parser).to receive(:parse_line).with(lines[next_line + 1]) {parsed}
+              allow(parser).to receive(:parse_line).with(nil) {nil}
+              allow(parser).to receive(:is_valid_line) {true}
+            }
 
-            shared_examples "yield and return next_line" do
-              it "should yield hash_entry(fields) and return next line" do
-                expect { |b|
-                  ret = parser.send(:parse_entry, lines, next_line, &b)
-                  expect(ret).to eq(next_line + 2)
-                }.to yield_with_args(hash_entry)
+            context "if parsed[:footer] is not nil or false" do
+              let(:parsed){{footer: true}}
+              it "should return parsed" do
+                expect(parser.send(:parse_entry, lines, next_line).is_empty(){}).to eq(true)
               end
             end
 
-            context "if parsed is not nil or false" do
-              before {
-                allow(parser).to receive(:parse_line).with(lines[next_line + 1]) {parsed}
-                allow(parser).to receive(:parse_line).with(nil) {nil}
-              }
-
-              context "if parsed[:footer] is not nil or false" do
-                let(:parsed){{footer: true}}
-                it "should return parsed" do
-                  expect(parser.send(:parse_entry, lines, next_line)).to eq(nil)
-                end
-              end
-
-              context "if parsed[:footer] is nil or false" do
-                context "if parsed[:key] = '1'" do
-                  let(:parsed){{key: "-1"}}
-                  let(:hash_entry){double("terminator_key")}
-
-                  before {
-                    allow(parser).to receive(:hash_entry).with([{:key=>nil, :value=>"     "}]) {hash_entry}
-                  }
-
-                  it "should return next + 2 and yield hash_entry(fields)" do
-                    expect { |b|
-                      ret = parser.send(:parse_entry, lines, next_line, &b)
-                      expect(ret).to eq(next_line + 3)
-                    }.to yield_with_args(hash_entry)
-                  end
-                end
-
-                context "if @terminator_key is not nil or false and parsed[:key] == @terminator_key" do
-                  let(:hash_entry){double("terminator_key and parsed[:key]")}
-                  let(:parsed){{key: terminator_key}}
-                  
-                  before {
-                    parser.instance_variable_set('@terminator_key',terminator_key)
-                  }
-                  
-                  it_behaves_like "yield and return next_line"
-                end
-              end
-            end
-
-            context "if the parsed is false or nil" do
-              before {
-                allow(parser).to receive(:parse_line).with(lines[(next_line + 1)]) {nil}
-                allow(parser).to receive(:parse_line).with(lines[(next_line + 2)]) {nil}
-              }
-
-              context "if the terminator key is nil" do
+            context "if parsed[:footer] is nil or false" do
+              context "if parsed[:key] = '1'" do
+                let(:parsed){{key: "-1"}}
                 let(:hash_entry){double("terminator_key")}
-                it_behaves_like "yield and return next_line"
-              end
-
-              context "if the next_line >= lines.length" do
-                before {
-                  parser.instance_variable_set('@terminator_key', terminator_key)
-                }
-                
-                let(:hash_entry){"line_length"}
-                it_behaves_like "yield and return next_line"
-              end
-
-              context "if it doesn't satisfy any of the if statement conditions (else)" do
-                let(:lines){[double("lines"), double("lines2"), double("lines3")]}
-                let(:hash_entry){"line_length"}
-                let(:terminator_key){double("fake_terminator_key")}
 
                 before {
-                  parser.instance_variable_set('@terminator_key', terminator_key)
+                  allow(parser).to receive(:hash_entry).with([{:key=>nil, :value=>"     "}]) {hash_entry}
+                  allow(parser).to receive(:is_valid_line) {true}
                 }
 
-                it "should yield hash_entry(fields) and return next line" do
+                it "should return next + 2 and yield hash_entry(fields)" do
                   expect { |b|
-                    ret = parser.send(:parse_entry, lines, next_line, &b)
-                    expect(ret).to eq(next_line + 3)
+                    detail = parser.send(:parse_entry, lines, next_line, &b)
+                    expect(detail.next_line).to eq(next_line + 3)
                   }.to yield_with_args(hash_entry)
                 end
               end
+
+              context "if @terminator_key is not nil or false and parsed[:key] == @terminator_key" do
+                let(:hash_entry){double("terminator_key and parsed[:key]")}
+                let(:parsed){{key: terminator_key}}
+
+                before {
+                  parser.instance_variable_set('@terminator_key',terminator_key)
+                }
+
+                it_behaves_like "yield and return next_line"
+              end
+            end
+          end
+
+          context "if the parsed is false or nil" do
+            before {
+              allow(parser).to receive(:parse_line).with(lines[(next_line + 1)]) {nil}
+              allow(parser).to receive(:parse_line).with(lines[(next_line + 2)]) {nil}
+              allow(parser).to receive(:is_valid_line) {true}
+            }
+
+            context "if the terminator key is nil" do
+              let(:hash_entry){double("terminator_key")}
+              it_behaves_like "yield and return next_line"
+            end
+
+            context "if the next_line >= lines.length" do
+              before {
+                parser.instance_variable_set('@terminator_key', terminator_key)
+              }
+
+              let(:hash_entry){"line_length"}
+              it_behaves_like "yield and return next_line"
+            end
+
+            context "if it doesn't satisfy any of the if statement conditions (else)" do
+              let(:lines){[double("lines"), double("lines2"), double("lines3")]}
+              let(:hash_entry){"line_length"}
+              let(:terminator_key){double("fake_terminator_key")}
+
+              before {
+                parser.instance_variable_set('@terminator_key', terminator_key)
+              }
+
+              it "should yield hash_entry(fields) and return next line" do
+                expect { |b|
+                  detail = parser.send(:parse_entry, lines, next_line, &b)
+                  expect(detail.next_line).to eq(next_line + 3)
+                }.to yield_with_args(hash_entry)
+              end
             end
           end
         end
       end
     end
+  end
 
-    describe '#parse_first_line' do
-      context "when the line is nil" do
-        let(:answer) {nil}
-        
-        before {
-          allow(parser).to receive(:parse_line).with(nil, /^\d+/) {answer}
-        }
+  describe '#parse_first_line' do
+    context "when the line is nil" do
+      let(:answer) {nil}
 
-        it "return nils, when the line entered is nil" do
-          expect(parser.send(:parse_first_line,answer)).to eq(answer)
-        end
+      before {
+        allow(parser).to receive(:parse_line).with(nil, /^\d+/) {answer}
+      }
+
+      it "return nils, when the line entered is nil" do
+        expect(parser.send(:parse_first_line,answer)[0]).to eq(answer)
       end
+    end
 
-      context "when the first[:footer] is true" do
-        let(:answer){{footer: true}}
-        let(:line) {"valid footer"}
+    context "when the first[:footer] is true" do
+      let(:answer){{footer: true}}
+      let(:line) {"valid footer"}
+
+      before {
+        allow(parser).to receive(:is_valid_line) {true}
+        allow(parser).to receive(:parse_line).with(line, /^\d+/) {answer}
+      }
+
+      it "returns first, which is {footer: true}" do
+        expect(parser.send(:parse_first_line, line)[0]).to eq(answer)
+      end
+    end
+
+    context "when the line is valid" do
+      before {
+        allow(parser).to receive(:parse_line).with(line,/^\d+/) {answer}
+      }
+
+      let(:line){"valid line"}
+
+      context "when the value for the key :key in first isn't the type key" do
+        let(:answer){{key: "1"}}
 
         before {
           allow(parser).to receive(:parse_line).with(line, /^\d+/) {answer}
         }
 
-        it "returns first, which is {footer: true}" do
-          expect(parser.send(:parse_first_line, line)).to eq(answer)
+        #type_key is "0"
+        it "should raise an error with the error message First line should start with #{@type_key}" do
+          expect{parser.send(:parse_first_line,line)[0]}.to raise_error(RuntimeError, "First line should start with 0")
         end
       end
 
-      context "when the line is valid" do
-        before {
-          allow(parser).to receive(:parse_line).with(line,/^\d+/) {answer}
-        }
+      context "when the line first[:key] is type_key" do
+        let(:answer){{key: "0"}}
 
-        let(:line){"valid line"}
-
-        context "when the value for the key :key in first isn't the type key" do
-          let(:answer){{key: "1"}}
-
-          before {
-            allow(parser).to receive(:parse_line).with(line, /^\d+/) {answer}
-          }
-          
-          #type_key is "0"
-          it "should raise an error with the error message First line should start with #{@type_key}" do
-            expect{parser.send(:parse_first_line,line)}.to raise_error(RuntimeError, "First line should start with 0")
-          end
-        end
-
-        context "when the line first[:key] is type_key" do
-          let(:answer){{key: "0"}}
-
-          it "should return the variable first which is parse_line(line, /^\d+/)" do
-            expect(parser.send(:parse_first_line,line)).to eq(answer)
-          end
-        end
-      end
-    end
-
-    describe '#parse_line' do
-      it "returns nil, when line is nil" do
-        expect(parser.send(:parse_line, nil)).to eq(nil)
-      end
-
-      shared_examples "white space" do
-        it "returns nil, when line contains white space character at the end or the start of the line" do
-          expect(parser.send(:parse_line,line)).to eq(nil)
-        end
-      end
-
-      context "when the line is a space" do
-        let(:line){" "}
-        it_behaves_like "white space"
-      end
-
-      context "when the line is three spaces" do
-        let(:line){"   "}
-        it_behaves_like "white space"
-      end
-
-      context "whe the line is empty" do
-        let(:line){""}
-        it_behaves_like "white space"
-      end
-
-      context "when the line is a tab and a newline character" do
-        let(:line){"\t\n"}
-        it_behaves_like "white space"
-      end
-
-      context "when the line is tab" do
-        let(:line){"\t"}
-        it_behaves_like "white space"
-      end
-
-      context "when the line is newline character" do
-        let(:line){"\n"}
-        it_behaves_like "white space"
-      end
-
-      context "when the line is return character" do
-        let(:line){"\r"}
-        it_behaves_like "white space"
-      end
-
-      context "when an ignore is inputted" do
-        it "returns nil, if the line matches the ignore inputted" do
-          expect(parser.send(:parse_line,"9",/\d/)).to eq(nil)
-        end
-
-        it "does not return nil, if the line doesn't match ignore inputted" do
-          expect(parser.send(:parse_line,"a",/\d/)).not_to eq(nil)
-        end
-
-        it "returns nil, the line matches preset ignore" do
-          expect(parser.send(:parse_line," ",/\d/)).to eq(nil)
-        end
-      end
-
-      context "if the line matches the footer"  do
-        let(:line) {'valid_footer'}
-        let(:answer) {double}
-
-        before {
-          allow(line).to receive(:match).with(/^\s*$/) {false}
-          allow(parser).to receive(:detect_footer).with(line) {answer}
-        }
-
-        it "delegate return value to detect_footer" do
-          expect(parser.send(:parse_line, line)).to eq(answer)
-        end
-      end
-
-      context "when the line doesn't match the footer" do
-        let(:line){"valid line"}
-        let(:continue_result){{key: "-1", value: line}}
-        
-        before {
-          allow(parser).to receive(:detect_footer).with(line) {nil}
-          allow(line).to receive(:match).with(/^\s*$/) {false}
-        }
-
-        context "when the line matches the line regex" do
-          context "when the match line matches regex match length" do
-            context "when the value regex order is within the array" do
-              before {
-                allow(line).to receive(:match).with(/\d/) {["1", "2", "3"]}
-              }
-
-              it "will return {key: m[@key_regex_order], value: value} with value equalling m[@value_regex_order].strip" do
-                expect(parser.send(:parse_line, line)).to eq({key: "2", value: "3"})
-              end
-            end
-
-            context "when the value regex order is outside the array" do
-              let(:match_result){[1, 2]}
-              before {
-                allow(line).to receive(:match).with(/\d/) {match_result}
-                allow(match_result).to receive(:length) {3}
-              }
-
-              it "will return {key: m[@key_regex_order, value: nil}" do
-                expect(parser.send(:parse_line, line)).to eq({key: 2, value: nil})
-              end
-            end
-          end
-
-          context "when the line matchdata doesn't match regex match length" do
-            before {
-              allow(line).to receive(:match).with(/\d/) {[1, 2, 3, 4]}
-            }
-
-            it "will return {key: '-1', value: line} where line is the inputted line" do
-              expect(parser.send(:parse_line, line)).to eq(continue_result)
-            end
-          end
-        end
-
-        context "when the line doesn't match the line regex" do
-          before {
-            allow(line).to receive(:match).with(/\d/) {nil}
-          }
-
-          it "will return {key: '-1', value: line} where line is the inputted line" do
-            expect(parser.send(:parse_line, line)).to eq(continue_result)
-            #todo: put a let
-          end
-        end
-      end
-    end
-
-    describe '#hash_entry' do
-      let(:value){double}
-      let(:key){double}
-      let(:key_value){double}
-      let(:key_hash){{:key => key, :value => key_value}}
-      
-      context "if fields only contains the type" do
-        let(:fields){[{:value => value}]}
-        
-        it "should return an hash with just the type" do
-          expect(parser.send(:hash_entry,fields)).to eq({'type' => value})
-        end
-      end
-
-      context "if the fields contatin the type and just a single key" do
-        let(:fields){[{:value => value}, key_hash]}
-        
-        it "should return an hash with the with the type and the key" do
-          expect(parser.send(:hash_entry, fields)).to eq('type' => value, key => key_value)
-        end
-      end
-
-      context "if the fields contain the type and two hashes which repeat a key" do
-        let(:fields){[{:value => value}, key_hash, key_hash]}
-        
-        it "should return an hash with the type and the repeated key contains an array" do
-          expect(parser.send(:hash_entry, fields)).to eq({'type' => value, key => [key_value, key_value]})
-        end
-      end
-
-      context "if the fields contain the type along with two hashes which repeat a key (one of the values is an array)" do
-        let(:fields){[{:value => value}, {:key => key, :value => [key_value]}, key_hash]}
-        
-        it "should return an hash with the type and the repeated key's value should be an array" do
-          expect(parser.send(:hash_entry, fields)).to eq({'type' => value, key => [key_value, key_value]})
-        end
-      end
-
-      context "if the field contains three repeated keys along with the type" do
-        let(:fields){[{:value => value}, key_hash, key_hash, key_hash]}
-        
-        it "should return an hash with the type and the repeated key's value should be an array" do
-          expect(parser.send(:hash_entry, fields)).to eq({'type' => value, key => [key_value, key_value, key_value]})
+        it "should return the variable first which is parse_line(line, /^\d+/)" do
+          expect(parser.send(:parse_first_line,line)[0]).to eq(answer)
         end
       end
     end
   end
+
+  describe '#parse_line' do
+    it "returns nil, when line is nil" do
+      expect(parser.send(:parse_line, nil)).to eq(nil)
+    end
+
+    shared_examples "white space" do
+      it "returns nil, when line contains white space character at the end or the start of the line" do
+        expect(parser.send(:parse_line,line)).to eq(nil)
+      end
+    end
+
+    context "when the line is a space" do
+      let(:line){" "}
+      it_behaves_like "white space"
+    end
+
+    context "when the line is three spaces" do
+      let(:line){"   "}
+      it_behaves_like "white space"
+    end
+
+    context "whe the line is empty" do
+      let(:line){""}
+      it_behaves_like "white space"
+    end
+
+    context "when the line is a tab and a newline character" do
+      let(:line){"\t\n"}
+      it_behaves_like "white space"
+    end
+
+    context "when the line is tab" do
+      let(:line){"\t"}
+      it_behaves_like "white space"
+    end
+
+    context "when the line is newline character" do
+      let(:line){"\n"}
+      it_behaves_like "white space"
+    end
+
+    context "when the line is return character" do
+      let(:line){"\r"}
+      it_behaves_like "white space"
+    end
+
+    context "when an ignore is inputted" do
+      it "returns nil, if the line matches the ignore inputted" do
+        expect(parser.send(:parse_line,"9",/\d/)).to eq(nil)
+      end
+
+      it "does not return nil, if the line doesn't match ignore inputted" do
+        expect(parser.send(:parse_line,"a",/\d/)).not_to eq(nil)
+      end
+
+      it "returns nil, the line matches preset ignore" do
+        expect(parser.send(:parse_line," ",/\d/)).to eq(nil)
+      end
+    end
+
+    context "if the line matches the footer"  do
+      let(:line) {'valid_footer'}
+      let(:answer) {double}
+
+      before {
+        allow(line).to receive(:match).with(/^\s*$/) {false}
+        allow(parser).to receive(:detect_footer).with(line) {answer}
+      }
+
+      it "delegate return value to detect_footer" do
+        expect(parser.send(:parse_line, line)).to eq(answer)
+      end
+    end
+
+    context "when the line doesn't match the footer" do
+      let(:line){"valid line"}
+      let(:continue_result){{key: "-1", value: line}}
+
+      before {
+        allow(parser).to receive(:detect_footer).with(line) {nil}
+        allow(line).to receive(:match).with(/^\s*$/) {false}
+      }
+
+      context "when the line matches the line regex" do
+        context "when the match line matches regex match length" do
+          context "when the value regex order is within the array" do
+            before {
+              allow(line).to receive(:match).with(/\d/) {["1", "2", "3"]}
+            }
+
+            it "will return {key: m[@key_regex_order], value: value} with value equalling m[@value_regex_order].strip" do
+              expect(parser.send(:parse_line, line)).to eq({key: "2", value: "3"})
+            end
+          end
+
+          context "when the value regex order is outside the array" do
+            let(:match_result){[1, 2]}
+            before {
+              allow(line).to receive(:match).with(/\d/) {match_result}
+              allow(match_result).to receive(:length) {3}
+            }
+
+            it "will return {key: m[@key_regex_order, value: nil}" do
+              expect(parser.send(:parse_line, line)).to eq({key: 2, value: nil})
+            end
+          end
+        end
+
+        context "when the line matchdata doesn't match regex match length" do
+          before {
+            allow(line).to receive(:match).with(/\d/) {[1, 2, 3, 4]}
+          }
+
+          it "will return {key: '-1', value: line} where line is the inputted line" do
+            expect(parser.send(:parse_line, line)).to eq(continue_result)
+          end
+        end
+      end
+
+      context "when the line doesn't match the line regex" do
+        before {
+          allow(line).to receive(:match).with(/\d/) {nil}
+        }
+
+        it "will return {key: '-1', value: line} where line is the inputted line" do
+          expect(parser.send(:parse_line, line)).to eq(continue_result)
+          #todo: put a let
+        end
+      end
+    end
+  end
+
+  describe '#hash_entry' do
+    let(:value){double}
+    let(:key){double}
+    let(:key_value){double}
+    let(:key_hash){{:key => key, :value => key_value}}
+
+    context "if fields only contains the type" do
+      let(:fields){[{:value => value}]}
+
+      it "should return an hash with just the type" do
+        expect(parser.send(:hash_entry,fields)).to eq({'type' => value})
+      end
+    end
+
+    context "if the fields contatin the type and just a single key" do
+      let(:fields){[{:value => value}, key_hash]}
+
+      it "should return an hash with the with the type and the key" do
+        expect(parser.send(:hash_entry, fields)).to eq('type' => value, key => key_value)
+      end
+    end
+
+    context "if the fields contain the type and two hashes which repeat a key" do
+      let(:fields){[{:value => value}, key_hash, key_hash]}
+
+      it "should return an hash with the type and the repeated key contains an array" do
+        expect(parser.send(:hash_entry, fields)).to eq({'type' => value, key => [key_value, key_value]})
+      end
+    end
+
+    context "if the fields contain the type along with two hashes which repeat a key (one of the values is an array)" do
+      let(:fields){[{:value => value}, {:key => key, :value => [key_value]}, key_hash]}
+
+      it "should return an hash with the type and the repeated key's value should be an array" do
+        expect(parser.send(:hash_entry, fields)).to eq({'type' => value, key => [key_value, key_value]})
+      end
+    end
+
+    context "if the field contains three repeated keys along with the type" do
+      let(:fields){[{:value => value}, key_hash, key_hash, key_hash]}
+
+      it "should return an hash with the type and the repeated key's value should be an array" do
+        expect(parser.send(:hash_entry, fields)).to eq({'type' => value, key => [key_value, key_value, key_value]})
+      end
+    end
+  end
+end

--- a/spec/pubmed_parser_spec.rb
+++ b/spec/pubmed_parser_spec.rb
@@ -10,4 +10,8 @@ describe PubMedParser do
       parser.open 'spec/support/example.nbib'
     end
   end
+
+  it 'should have the friendly_name' do
+      expect(parser.friendly_name()).to eq("PubMed/NBIB Parser")
+  end
 end

--- a/spec/ris_parser_spec.rb
+++ b/spec/ris_parser_spec.rb
@@ -9,5 +9,9 @@ describe RISParser do
     it 'parses the input file correctly' do
       parser.open 'spec/support/example.ris'
     end
+
+    it 'should have the friendly_name' do
+      expect(parser.friendly_name()).to eq("Refman/RIS Parser")
+    end
   end
 end

--- a/spec/support/example.ciw
+++ b/spec/support/example.ciw
@@ -23,4 +23,47 @@ SN 1041-4347
 UT WOS:000341571100009
 ER
 
+AU Eltabakh, Mohamed
+   Aref, Walid
+   Elmagarmid, Ahmed
+   Ouzzani, Mourad
+TI Second HandsOn DB: Managing Data Dependencies Involving Human Actions(title)
+SO IEEE TRANSACTIONS ON KNOWLEDGE AND DATA ENGINEERING(journal title, in full)
+DT Article
+AB abstract
+VL 26
+IS 9
+BP 2193
+EP 2206
+J9 CLIN GENET
+JI Clin. Genet.
+PD SEP
+PY 2014
+LA ENGLISH
+UR www.rayyan.qcri.com
+SN 1041-4347
+UT WOS:000341571100009
+ER
+
+AU Eltabakh, Mohamed
+   Aref, Walid
+   Elmagarmid, Ahmed
+   Ouzzani, Mourad
+TI Third HandsOn DB: Managing Data Dependencies Involving Human Actions(title)
+SO IEEE TRANSACTIONS ON KNOWLEDGE AND DATA ENGINEERING(journal title, in full)
+DT Article
+AB abstract
+VL 26
+IS 9
+BP 2193
+EP 2206
+J9 CLIN GENET
+JI Clin. Genet.
+PD SEP
+PY 2014
+LA ENGLISH
+UR www.rayyan.qcri.com
+SN 1041-4347
+UT WOS:000341571100009
+
 EF

--- a/spec/support/example_utf8_with_bom.txt
+++ b/spec/support/example_utf8_with_bom.txt
@@ -1,0 +1,1 @@
+﻿مثال لمحتوى - Example content

--- a/spec/support/example_utf8_without_bom.txt
+++ b/spec/support/example_utf8_without_bom.txt
@@ -1,0 +1,1 @@
+مثال لمحتوى - Example content

--- a/test.rb
+++ b/test.rb
@@ -8,14 +8,14 @@ require 'ref_parsers'
 filename = ARGV[0]
 raise "USAGE: #{__FILE__} <input-file>" if filename.nil?
 parsers = {
-  '.ris' => RefParsers::RISParser,
-  '.enw' => RefParsers::EndNoteParser,
-  '.nbib' => RefParsers::PubMedParser,
-  '.ciw' => RefParsers::CIWParser
+  '.ris' => lambda {RefParsers::RISParser.new(:import_entry)},
+  '.enw' => lambda {RefParsers::EndNoteParser.new()},
+  '.nbib' => lambda {RefParsers::PubMedParser.new()},
+  '.ciw' => lambda {RefParsers::CIWParser.new(:import_entry)}
 }
-klass = parsers[File.extname(filename)]
-if klass
-  klass.new.open(ARGV[0]).each do |entry|
+parser_fac = parsers[File.extname(filename)]
+if parser_fac
+  parser_fac.call().open(ARGV[0]).each do |entry|
     puts "Entry"
     entry.each do |k, v|
       puts "  #{k}: #{v}"

--- a/test_dir.rb
+++ b/test_dir.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'ref_parsers'
+
+dir_path = ARGV[0]
+raise "USAGE: #{__FILE__} <input-directory-path>" if dir_path.nil?
+raise "Directory '#{dir_path}' is not valid" if not File.directory?(dir_path)
+
+parsers = {
+  '.ris' => lambda {RefParsers::RISParser.new(:import_entry)},
+  '.enw' => lambda {RefParsers::EndNoteParser.new()},
+  '.nbib' => lambda {RefParsers::PubMedParser.new()},
+  '.ciw' => lambda {RefParsers::CIWParser.new(:import_entry)}
+}
+
+Dir.entries(dir_path).select {|f| !File.directory? f}.each do |cur_file|
+	parser_fac = parsers[File.extname(cur_file)]
+    full_path = File.join(dir_path, cur_file)
+	if parser_fac
+      puts "Parsing file #{full_path}"
+      begin
+          entries = parser_fac.call().open(full_path) do |summary|
+            puts summary
+          end
+      rescue => ex
+        puts "Error parsing file #{full_path}. #{ex}"
+      end
+	else
+	  puts "Could not identify the type of file #{full_path}"
+	end
+end


### PR DESCRIPTION
The changes are tracked in the issues pages of the fork:
https://github.com/kariem2k/ref_parsers/issues?q=is%3Aissue+is%3Aclosed   

Summary of the changes:
- Line Parser does not ignore Unicode's files BOM
- If footer comes to the end of the file without any terminators the entire entry was being ignored
- For terminator based parser, It was causing an exception, if there is no start tag but there is a terminator tag.
- Gibberish lines before the start tag or between the end tag and the start tag, caused an exception.
- No new line between last segment and the new segment, caused an exception.
- Exceptions from the parser should to include the location of the error within the file
- The need for a test file to test entire directories
- Returning summary of parsing
- Minor change for a very minor performance issue